### PR TITLE
PATCH `/choice` API 추가

### DIFF
--- a/src/main/java/com/warmingup/cardera/controller/UserChoiceController.java
+++ b/src/main/java/com/warmingup/cardera/controller/UserChoiceController.java
@@ -1,0 +1,22 @@
+package com.warmingup.cardera.controller;
+
+import com.warmingup.cardera.dto.UserChoiceRequestDto;
+import com.warmingup.cardera.service.UserChoiceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserChoiceController {
+    private final UserChoiceService userChoiceService;
+
+    @PatchMapping("/choice")
+    public ResponseEntity<String> updateChoice(@RequestBody UserChoiceRequestDto userChoiceRequestDto) {
+        userChoiceService.updateUserChoice(userChoiceRequestDto);
+        return ResponseEntity.ok().body("Success");
+    }
+}

--- a/src/main/java/com/warmingup/cardera/domain/entity/UserChoice.java
+++ b/src/main/java/com/warmingup/cardera/domain/entity/UserChoice.java
@@ -20,4 +20,8 @@ public class UserChoice {
     @Builder.Default
     @Column(nullable = false)
     private int choiceCount = 0;
+
+    public void incrementCount() {
+        this.choiceCount += 1;
+    }
 }

--- a/src/main/java/com/warmingup/cardera/domain/entity/UserChoice.java
+++ b/src/main/java/com/warmingup/cardera/domain/entity/UserChoice.java
@@ -1,0 +1,23 @@
+package com.warmingup.cardera.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Table
+public class UserChoice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private double multiple;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private int choiceCount = 0;
+}

--- a/src/main/java/com/warmingup/cardera/domain/repository/UserChoiceRepository.java
+++ b/src/main/java/com/warmingup/cardera/domain/repository/UserChoiceRepository.java
@@ -1,0 +1,10 @@
+package com.warmingup.cardera.domain.repository;
+
+import com.warmingup.cardera.domain.entity.UserChoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserChoiceRepository extends JpaRepository<UserChoice, Long> {
+    Optional<UserChoice> findByMultiple(double multiple);
+}

--- a/src/main/java/com/warmingup/cardera/dto/UserChoiceRequestDto.java
+++ b/src/main/java/com/warmingup/cardera/dto/UserChoiceRequestDto.java
@@ -1,0 +1,8 @@
+package com.warmingup.cardera.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserChoiceRequestDto {
+    private double multiple;
+}

--- a/src/main/java/com/warmingup/cardera/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/warmingup/cardera/exception/ExceptionControllerAdvice.java
@@ -1,0 +1,16 @@
+package com.warmingup.cardera.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFoundException(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+}

--- a/src/main/java/com/warmingup/cardera/service/UserChoiceService.java
+++ b/src/main/java/com/warmingup/cardera/service/UserChoiceService.java
@@ -1,0 +1,25 @@
+package com.warmingup.cardera.service;
+
+import com.warmingup.cardera.domain.entity.UserChoice;
+import com.warmingup.cardera.domain.repository.UserChoiceRepository;
+import com.warmingup.cardera.dto.UserChoiceRequestDto;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserChoiceService {
+    private final UserChoiceRepository userChoiceRepository;
+
+    @Transactional
+    public Long updateUserChoice(UserChoiceRequestDto userChoiceRequestDto) {
+        // 1. multiple에 해당하는 userChoice 필드 가져오기
+        UserChoice userChoice = userChoiceRepository.findByMultiple(userChoiceRequestDto.getMultiple())
+                .orElseThrow(() -> new EntityNotFoundException("Entity not found with multiple: " + userChoiceRequestDto.getMultiple()));
+        // 2. 해당 필드의 choiceCount에 1을 더해서 업데이트하기
+        userChoice.incrementCount();
+        return userChoice.getId();
+    }
+}


### PR DESCRIPTION
# PATCH `/choice` API 추가
* [API 명세서](https://www.notion.so/b-side/8584865981394f9fb40f99e7924c13df)

## Feature
* `UserChoice`, `UserChoiceRepository`, `UserChoiceService`, `UserChoiceController`, `UserChoiceRequestDto` 추가
* `ExceptionControllerAdvice` 추가 - 앞으로도 에러 핸들링 할 때 @ControllerAdvice, @ ExceptionHandler 어노테이션 이용하는 걸로 통일해도 좋을 것 같습니다!
