### PR TITLE
RDS 세팅 및 Profile 환경 별 설정 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 .DS_Store
+rds-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:h2:~/cardera-db
+    username: admin
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    generate-ddl: 'true'
+    hibernate:
+      ddl-auto: update
+
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+      path: /h2-console

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+    import: rds-prod.yml
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,20 +1,13 @@
 spring:
-  datasource:
-    url: jdbc:h2:~/cardera-db
-    username: user
-    password:
-    driverClassName: org.h2.Driver
+  profiles:
+    active: local
+
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    generate-ddl: 'true'
-    hibernate:
-      ddl-auto: create
-  h2:
-    console:
-      enabled: true
-      settings:
-        web-allow-others: true
-      path: /h2-console
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
 logging:
   level:
     org.hibernate.type: trace


### PR DESCRIPTION
# RDS 세팅 및 Profile 환경 별 설정 분리
* AWS EC2 배포 환경에서 RDS를 사용하기 위한 환경 설정

## Feature
- Profile 환경 별로 설정 파일 분리: `application-{profile}.yml`
- `local` 환경에서는 기존과 동일하게 h2를 사용하고, `prod` 환경에서는 RDS를 db로 사용
- ddl-auto: create -> update 로 변경 (embedded mode)
- RDS와 관련된 세부 정보(url, username, password)는 `rds-prod.yml` 파일을 resources 폴더 아래에 추가해주어야 함

## 공유사항
* H2를 embedded mode로 변경한 후에 username과 password가 맞지 않는다는 에러가 발생한다면 기존에 생성되어있는 ~/cardera-db 파일을 삭제 후 다시 실행하면 됩니다!
* 기본적으로 `local` 환경에서 실행되도록 설정해놓았는데, application.yml 에서 local -> prod 로 변경하면 운영 환경에서 RDS와 연결 할 수 있습니다! (위에 언급한 것처럼 `rds-prod.yml` 파일이 필요합니다)